### PR TITLE
Update allowed CORS origins in configuration

### DIFF
--- a/management/src/main/java/authentication/management/config/CorsGlobalConfiguration.java
+++ b/management/src/main/java/authentication/management/config/CorsGlobalConfiguration.java
@@ -29,8 +29,8 @@ public class CorsGlobalConfiguration {
         // ✅ Orígenes permitidos - usar patterns para mayor flexibilidad
         configuration.setAllowedOriginPatterns(Arrays.asList(
                 "http://localhost:4200",     // Angular desarrollo
-                "http://localhost:3000",     // React desarrollo (si aplica)
-                "https://tu-dominio.com"     // Producción (actualizar cuando sea necesario)
+                "http://localhost:3000",
+                "https://materialauth.whispererlab.com/"
         ));
 
         // ✅ Métodos HTTP permitidos


### PR DESCRIPTION
Replaces the production CORS origin from 'https://tu-dominio.com' to 'https://materialauth.whispererlab.com/' in CorsGlobalConfiguration. This ensures that only the correct production domain is permitted for cross-origin requests.